### PR TITLE
token.verify – return err if no token in auth header

### DIFF
--- a/index.js
+++ b/index.js
@@ -190,6 +190,8 @@ module.exports = function createTownship (config, db) {
 
   township.verify = function (req, res, cb) {
     var rawToken = creds(req)
+    if (!rawToken) return cb('token auth required')
+
     jwt.verify(rawToken, function (err, token) {
       if (err) return cb(err)
       if (!token) {

--- a/test/test.js
+++ b/test/test.js
@@ -117,6 +117,15 @@ test('verify a token', function (t) {
   })
 })
 
+test('require authorization header', function (t) {
+  var headers = {}
+  nets({url: root + '/verifytoken', method: 'GET', headers: headers, json: true}, function (err, resp, body) {
+    t.ifErr(err)
+    t.equals(resp.statusCode, 400, '400 status response')
+    t.end()
+  })
+})
+
 test('stop test server', function (t) {
   app.db.close(function () {
     server.close(function () {


### PR DESCRIPTION
a little fix to return early if `creds` doesn't return a token